### PR TITLE
Dockerfile: Add the summary field and fix-up the image description.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY --from=build /usr/bin/ghostunnel /usr/bin/ghostunnel
 ENTRYPOINT ["/usr/bin/ghostunnel"]
 
 LABEL io.k8s.display-name="OpenShift Ghostunnel" \
-      io.k8s.description="This is an image used by metering-operator to to install and run Ghostunnel." \
+      io.k8s.description="This is an image used by the Metering Operator to install and run Ghostunnel." \
+      summary="This is an image used by the Metering Operator to install and run Ghostunnel." \
       io.openshift.tags="openshift" \
       maintainer="<metering-team@redhat.com>"

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -11,6 +11,7 @@ COPY --from=build /usr/bin/ghostunnel /usr/bin/ghostunnel
 ENTRYPOINT ["/usr/bin/ghostunnel"]
 
 LABEL io.k8s.display-name="OpenShift Ghostunnel" \
-      io.k8s.description="This is an image used by metering-operator to to install and run Ghostunnel." \
+      io.k8s.description="This is an image used by the Metering Operator to install and run Ghostunnel." \
+      summary="This is an image used by the Metering Operator to install and run Ghostunnel." \
       io.openshift.tags="openshift" \
       maintainer="<metering-team@redhat.com>"


### PR DESCRIPTION
The summary label field is required to pass the inherit_labels CVP check that this image was previously failing.

This also updates the label description fields, removing a redundant 'to' and replacing the metering operator name.